### PR TITLE
Service file for websockets server

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,22 @@ server/consensus_monitor_server.py --api <api_server_node> --rpc <rpc_server_nod
 - `port` is set to 9001 by default
 - `interval` is set to 1 by default
 
+- This can be run inside a `tmux` session.
+
+#### Service
+
+You can run the websockets server as a service:
+
+1. Modify the `consensus-monitor-server.service` file as appropriate.
+2. Make a copy of `consensus-monitor-server.service` or create a link to it in `/etc/systemd/system/`.
+3. Enable and start the service:
+```
+systemctl daemon-reload
+systemctl enable consensus-monitor-server.service
+systemctl start consensus-monitor-server.service
+systemctl status consensus-monitor-server.service
+```
+
 ### Web client
 
 You can serve the web client using the `http` package:

--- a/server/consensus-monitor-server.service
+++ b/server/consensus-monitor-server.service
@@ -1,0 +1,13 @@
+[Unit]
+Description="Cosmos Consensus Monitor"
+
+[Service]
+User={USER}
+Environment="PATH=/usr/local/go/bin:{USER_HOME}/go/bin:$PATH"
+WorkingDirectory={USER_HOME}/cosmos-consensus-monitor/server
+ExecStart={USER_HOME}/cosmos-consensus-monitor/.env/bin/python consensus_monitor_server.py -a <api_node_address> -r <rpc_node_address>
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
- Added a sample file to run the websockets server as a service.
- Updated the README with instructions to set up the service.
- Closes #4 