### PR TITLE
Bandwidth and efficency improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.vscode
+
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/client/js/consensus.js
+++ b/client/js/consensus.js
@@ -10,7 +10,11 @@ let precommits_ratio_div = document.getElementById("precommits-ratio");
 let precommits_vp_div = document.getElementById("precommits-voting-power");
 let precommits_validators = document.getElementById("precommits-validators");
 
-var wso = new WebSocket("ws://" + document.domain + ":" + "9001" + "/");
+var wsProto = "ws://";
+if (window.location.protocol === "https:") {
+    wsProto = "wss://";
+}
+var wso = new WebSocket(wsProto + document.domain + ":" + "9001" + "/");
 
 function populate_validators(monikers) {
     while (prevotes_validators.firstChild) {

--- a/lint.sh
+++ b/lint.sh
@@ -8,13 +8,13 @@ then
 	python -m autopep8 --in-place --recursive .
 
     echo "Linting python"
-    python -m pylint server/*.py --disable=E1101,W1203
+    python -m pylint server/*.py --disable=E1101,W1203,C0103
 fi
 
 if [ $CI ]
 then
     echo "Linting python"
-    python -m pylint server/*.py --disable=W0511,E0401,R0801,E1101,W1203
+    python -m pylint server/*.py --disable=W0511,E0401,R0801,E1101,W1203,C0103
     if [ $? -ne 0 ]
     then
     	pylint=1

--- a/lint.sh
+++ b/lint.sh
@@ -8,13 +8,13 @@ then
 	python -m autopep8 --in-place --recursive .
 
     echo "Linting python"
-    python -m pylint server/*.py --disable=E1101,W1203,C0103
+    python -m pylint server/*.py --disable=E1101,W1203
 fi
 
 if [ $CI ]
 then
     echo "Linting python"
-    python -m pylint server/*.py --disable=W0511,E0401,R0801,E1101,W1203,C0103
+    python -m pylint server/*.py --disable=W0511,E0401,R0801,E1101,W1203
     if [ $? -ne 0 ]
     then
     	pylint=1

--- a/server/consensus_monitor_server.py
+++ b/server/consensus_monitor_server.py
@@ -26,19 +26,19 @@ import websockets
 MAX_CONCURRENT_SEND_COROS = 100
 
 
-async def gather_limit(n, *aws, return_exceptions=False):
+async def gather_limit(max_coros, *awaits, return_exceptions=False):
     """
-    Like asyncio.gather but concurrency is limited to n at a time.
+    Like asyncio.gather but concurrency is limited to 'max_coros' at a time.
 
     Source: https://stackoverflow.com/a/61478547
     """
 
-    semaphore = asyncio.Semaphore(n)
+    semaphore = asyncio.Semaphore(max_coros)
 
-    async def sem_aw(aw):
+    async def sem_aw(coro):
         async with semaphore:
-            return await aw
-    return await asyncio.gather(*(sem_aw(aw) for aw in aws), return_exceptions=return_exceptions)
+            return await coro
+    return await asyncio.gather(*(sem_aw(aw) for aw in awaits), return_exceptions=return_exceptions)
 
 # Consensus monitor class
 

--- a/server/consensus_monitor_server.py
+++ b/server/consensus_monitor_server.py
@@ -25,6 +25,7 @@ import websockets
 # Also probably a bit more CPU usage?
 MAX_CONCURRENT_SEND_COROS = 100
 
+
 async def gather_limit(n, *aws, return_exceptions=False):
     """
     Like asyncio.gather but concurrency is limited to n at a time.
@@ -40,6 +41,8 @@ async def gather_limit(n, *aws, return_exceptions=False):
     return await asyncio.gather(*(sem_aw(aw) for aw in aws), return_exceptions=return_exceptions)
 
 # Consensus monitor class
+
+
 class ConsensusMonitor:
     """
     Periodically requests and parses consensus data from a Cosmos node.
@@ -365,7 +368,7 @@ class ConsensusMonitor:
                 logging.info('Node is offline')
                 self.node_online = False
             return self.state != self.old_state
-        
+
         return self.state != self.old_state
 
     async def add_client(self, websocket):
@@ -407,7 +410,8 @@ class ConsensusMonitor:
                 state_json = json.dumps(self.state)
                 results = await gather_limit(
                     MAX_CONCURRENT_SEND_COROS,
-                    *[client.send(state_json) for client in self.client_websockets],
+                    *[client.send(state_json)
+                      for client in self.client_websockets],
                     return_exceptions=True,
                 )
                 for result in results:
@@ -417,7 +421,7 @@ class ConsensusMonitor:
                     if isinstance(result, websockets.exceptions.ConnectionClosedOK):
                         logging.exception(
                             f'monitor> ConnectionClosedOK: {result}', exc_info=False)
-            
+
             if self.node_online:
                 await asyncio.sleep(self.interval)
             else:

--- a/server/consensus_monitor_server.py
+++ b/server/consensus_monitor_server.py
@@ -19,7 +19,6 @@ import sys
 import asyncio
 import requests
 import websockets
-import copy
 
 
 # Consensus monitor class
@@ -307,7 +306,7 @@ class ConsensusMonitor:
         False is returned otherwise.
         """
 
-        self.old_state = copy.deepcopy(self.state)
+        self.old_state = self.state
         self.state = {}
         version = self.get_version()
         if version:

--- a/server/consensus_monitor_server.py
+++ b/server/consensus_monitor_server.py
@@ -35,8 +35,6 @@ async def gather_limit(max_coros, *awaits, return_exceptions=False):
             return await coro
     return await asyncio.gather(*(sem_aw(aw) for aw in awaits), return_exceptions=return_exceptions)
 
-# Consensus monitor class
-
 
 class ConsensusMonitor:
     """

--- a/server/consensus_monitor_server.py
+++ b/server/consensus_monitor_server.py
@@ -20,11 +20,6 @@ import asyncio
 import requests
 import websockets
 
-# The maximum number of websocket .send coroutines running at once
-# Larger number means more concurrent bandwidth usage, each message is ~383 bytes
-# Also probably a bit more CPU usage?
-MAX_CONCURRENT_SEND_COROS = 100
-
 
 async def gather_limit(max_coros, *awaits, return_exceptions=False):
     """
@@ -53,6 +48,11 @@ class ConsensusMonitor:
     RPC_ENDPOINT_ABCI_INFO = '/abci_info'
     RPC_ENDPOINT_BLOCK = '/block'
     RPC_ENDPOINT_CONSENSUS = '/consensus_state'
+
+    # The maximum number of websocket .send coroutines running at once
+    # Larger number means more concurrent bandwidth usage, each message is ~383 bytes
+    # Also probably a bit more CPU usage?
+    MAX_CONCURRENT_SEND_COROS = 100
 
     def __init__(self,
                  api_server: str,
@@ -410,7 +410,7 @@ class ConsensusMonitor:
             if await self.update_state():
                 state_json = json.dumps(self.state)
                 results = await gather_limit(
-                    MAX_CONCURRENT_SEND_COROS,
+                    self.MAX_CONCURRENT_SEND_COROS,
                     *[client.send(state_json)
                       for client in self.client_websockets],
                     return_exceptions=True,

--- a/server/consensus_monitor_server.py
+++ b/server/consensus_monitor_server.py
@@ -319,7 +319,7 @@ class ConsensusMonitor:
             if self.node_online:
                 logging.info('Node is offline')
                 self.node_online = False
-            return self.state == self.old_state
+            return self.state != self.old_state
 
         current_height = self.get_block_height()
         if current_height:
@@ -332,7 +332,7 @@ class ConsensusMonitor:
             if self.node_online:
                 logging.info('Node is offline')
                 self.node_online = False
-            return self.state == self.old_state
+            return self.state != self.old_state
 
         round_state = self.get_round_state()
         if round_state:
@@ -346,9 +346,9 @@ class ConsensusMonitor:
             if self.node_online:
                 logging.info('Node is offline')
                 self.node_online = False
-            return self.state == self.old_state
+            return self.state != self.old_state
         
-        return self.state == self.old_state
+        return self.state != self.old_state
 
     async def add_client(self, websocket):
         """

--- a/server/consensus_monitor_server.py
+++ b/server/consensus_monitor_server.py
@@ -453,23 +453,10 @@ class ConsensusMonitorServer:
         await self.monitor.add_client(websocket)
         logging.info('%s client(s) connected.', len(
             self.monitor.client_websockets))
-        try:
-            async for message in websocket:
-                data = json.loads(message)
-                logging.info(f'Received message: {data}')
-        except websockets.exceptions.ConnectionClosedError as cce:
-            logging.exception(
-                f'handler> ConnectionClosedError: {cce}', exc_info=False)
-        except ConnectionResetError as cre:
-            logging.exception(
-                f'handler> ConnectionResetError: {cre}', exc_info=False)
-        except asyncio.exceptions.IncompleteReadError as ire:
-            logging.exception(
-                f'handler> IncompleteReadError: {ire}', exc_info=False)
-        finally:
-            await self.monitor.remove_client(websocket)
-            logging.info('%s client(s) connected.', len(
-                self.monitor.client_websockets))
+        await websocket.wait_closed()
+        await self.monitor.remove_client(websocket)
+        logging.info('%s client(s) connected.', len(
+            self.monitor.client_websockets))
 
 
 if __name__ == "__main__":

--- a/server/consensus_monitor_server.py
+++ b/server/consensus_monitor_server.py
@@ -63,6 +63,7 @@ class ConsensusMonitor:
         self.interval = interval_seconds
         self.node_online = False
         self.state = {}
+        self.old_state = {}
         self.addr_moniker_dict = {}
         self.client_websockets = []
 


### PR DESCRIPTION
- Websocket messages are only sent when the state has changed, yielding massive outgoing bandwidth reductions
- Sending state updates is now done concurrently, so all websocket clients (up to a limit) will get the update at the same time
- Unnecessary websocket incoming messsage handling was removed
- ~~`C0103` aka `invalid-name` was added to the pylint ignore list because it's stupid and complain about okay function args like `n`~~